### PR TITLE
Update API key after request has been handled

### DIFF
--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -28,11 +28,7 @@ class AuthenticateApiKey
             return $this->unauthorizedResponse();
         }
 
-        // Update this api key's last_used_at and last_ip_address
-        $apiKey->update([
-            'last_used_at'    => Carbon::now(),
-            'last_ip_address' => $request->ip(),
-        ]);
+        $lastUsedAt = Carbon::now();
 
         $apikeyable = $apiKey->apikeyable;
 
@@ -48,7 +44,15 @@ class AuthenticateApiKey
 
         event(new ApiKeyAuthenticated($request, $apiKey));
 
-        return $next($request);
+        $response = $next($request);
+
+        // Update this api key's last_used_at and last_ip_address
+        $apiKey->update([
+            'last_used_at'    => $lastUsedAt,
+            'last_ip_address' => $request->ip(),
+        ]);
+
+        return $response;
     }
 
     protected function unauthorizedResponse()


### PR DESCRIPTION
We cannot use the reader nodes on API endpoints when we are doing a write in the middleware. We use a sticky connection setting so all queries after the first write will do their reads on the writer nodes in order to prevent dangerous reads from the reader when it may have just been changed on the writer and not replicated. If we do a write in the middleware before the request is handled, we can never use the reader.